### PR TITLE
Add component tags and update Action Controller operation names

### DIFF
--- a/lib/rails/instrumentation/patch.rb
+++ b/lib/rails/instrumentation/patch.rb
@@ -6,9 +6,9 @@ module Rails
           alias_method :process_action_original, :process_action
 
           def process_action(method_name, *args)
-            # this naming scheme 'method.class' is how we ensure that the notification in the
+            # this naming scheme 'class.method' is how we ensure that the notification in the
             # subscriber is the same one
-            name = "#{method_name}.#{self.class.name}"
+            name = "#{self.class.name}.#{method_name}"
             scope = ::Rails::Instrumentation.tracer.start_active_span(name)
 
             # skip adding tags here. Getting the complete set of information is

--- a/lib/rails/instrumentation/subscriber.rb
+++ b/lib/rails/instrumentation/subscriber.rb
@@ -35,6 +35,10 @@ module Rails
             end
           end
         end
+
+        def span_tags(tags)
+          self::BASE_TAGS.clone.merge(tags)
+        end
       end
     end
   end

--- a/lib/rails/instrumentation/subscribers/action_cable_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_cable_subscriber.rb
@@ -19,8 +19,7 @@ module Rails
 
       class << self
         def perform_action(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'channel_class' => event.payload[:channel_class],
             'action' => event.payload[:action],
             'data' => event.payload[:data]
@@ -30,8 +29,7 @@ module Rails
         end
 
         def transmit(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'channel_class' => event.payload[:channel_class],
             'data' => event.payload[:data],
             'via' => event.payload[:via]
@@ -41,8 +39,7 @@ module Rails
         end
 
         def transmit_subscription_confirmation(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'channel_class' => event.payload[:channel_class]
           )
 
@@ -50,8 +47,7 @@ module Rails
         end
 
         def transmit_subscription_rejection(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'channel_class' => event.payload[:channel_class]
           )
 
@@ -59,8 +55,7 @@ module Rails
         end
 
         def broadcast(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'broadcasting' => event.payload[:broadcasting],
             'message' => event.payload[:message],
             'coder' => event.payload[:coder]

--- a/lib/rails/instrumentation/subscribers/action_cable_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_cable_subscriber.rb
@@ -13,49 +13,58 @@ module Rails
         broadcast
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActionCable' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def perform_action(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'channel_class' => event.payload[:channel_class],
             'action' => event.payload[:action],
             'data' => event.payload[:data]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def transmit(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'channel_class' => event.payload[:channel_class],
             'data' => event.payload[:data],
             'via' => event.payload[:via]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def transmit_subscription_confirmation(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'channel_class' => event.payload[:channel_class]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def transmit_subscription_rejection(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'channel_class' => event.payload[:channel_class]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def broadcast(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'broadcasting' => event.payload[:broadcasting],
             'message' => event.payload[:message],
             'coder' => event.payload[:coder]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/action_controller_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_controller_subscriber.rb
@@ -27,8 +27,7 @@ module Rails
 
       class << self
         def write_fragment(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key.write' => event.payload[:key]
           )
 
@@ -36,8 +35,7 @@ module Rails
         end
 
         def read_fragment(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key.read' => event.payload[:key]
           )
 
@@ -45,8 +43,7 @@ module Rails
         end
 
         def expire_fragment(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key.expire' => event.payload[:key]
           )
 
@@ -54,8 +51,7 @@ module Rails
         end
 
         def exist_fragment?(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key.exist' => event.payload[:key]
           )
 
@@ -63,8 +59,7 @@ module Rails
         end
 
         def write_page(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'path.write' => event.payload[:path]
           )
 
@@ -72,8 +67,7 @@ module Rails
         end
 
         def expire_page(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'path.expire' => event.payload[:path]
           )
 
@@ -81,8 +75,7 @@ module Rails
         end
 
         def start_processing(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'controller' => event.payload[:controller],
             'controller.action' => event.payload[:action],
             'request.params' => event.payload[:params],
@@ -95,10 +88,9 @@ module Rails
         end
 
         def process_action(event)
-          span_name = "#{event.payload[:action]}.#{event.payload[:controller]}"
+          span_name = "#{event.payload[:controller]}.#{event.payload[:action]}"
 
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'controller' => event.payload[:controller],
             'controller.action' => event.payload[:action],
             'request.params' => event.payload[:params],
@@ -124,8 +116,7 @@ module Rails
         end
 
         def send_file(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'path.send' => event.payload[:path]
           )
 
@@ -143,8 +134,7 @@ module Rails
         end
 
         def redirect_to(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'http.status_code' => event.payload[:status],
             'redirect.url' => event.payload[:location]
           )
@@ -153,8 +143,7 @@ module Rails
         end
 
         def halted_callback(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'filter' => event.payload[:filter]
           )
 
@@ -162,8 +151,7 @@ module Rails
         end
 
         def unpermitted_parameters(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'unpermitted_keys' => event.payload[:keys]
           )
 

--- a/lib/rails/instrumentation/subscribers/action_controller_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_controller_subscriber.rb
@@ -21,64 +21,75 @@ module Rails
         unpermitted_parameters
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActionController' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def write_fragment(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key.write' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def read_fragment(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key.read' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def expire_fragment(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key.expire' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def exist_fragment?(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key.exist' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def write_page(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'path.write' => event.payload[:path]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def expire_page(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'path.expire' => event.payload[:path]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def start_processing(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'controller' => event.payload[:controller],
             'controller.action' => event.payload[:action],
             'request.params' => event.payload[:params],
             'request.format' => event.payload[:format],
             'http.method' => event.payload[:method],
             'http.url' => event.payload[:path]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
@@ -86,7 +97,8 @@ module Rails
         def process_action(event)
           span_name = "#{event.payload[:action]}.#{event.payload[:controller]}"
 
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'controller' => event.payload[:controller],
             'controller.action' => event.payload[:action],
             'request.params' => event.payload[:params],
@@ -95,8 +107,9 @@ module Rails
             'http.url' => event.payload[:path],
             'http.status_code' => event.payload[:status],
             'view.runtime.ms' => event.payload[:view_runtime],
-            'db.runtime.ms' => event.payload[:db_runtime]
-          }
+            'db.runtime.ms' => event.payload[:db_runtime],
+            'span.kind' => 'server'
+          )
 
           # Only append these tags onto the active span created by the patched 'process_action'
           # Otherwise, create a new span for this notification as usual
@@ -111,9 +124,10 @@ module Rails
         end
 
         def send_file(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'path.send' => event.payload[:path]
-          }
+          )
 
           # there may be additional keys in the payload. It might be worth
           # trying to tag them too
@@ -125,30 +139,33 @@ module Rails
           # no defined keys, but user keys may be passed in. Might want to add
           # them at some point
 
-          Utils.trace_notification(event: event, tags: tags)
+          Utils.trace_notification(event: event, tags: BASE_TAGS)
         end
 
         def redirect_to(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'http.status_code' => event.payload[:status],
             'redirect.url' => event.payload[:location]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def halted_callback(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'filter' => event.payload[:filter]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def unpermitted_parameters(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'unpermitted_keys' => event.payload[:keys]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/action_mailer_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_mailer_subscriber.rb
@@ -17,8 +17,7 @@ module Rails
 
       class << self
         def receive(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'mailer' => event.payload[:mailer],
             'message.id' => event.payload[:message_id],
             'message.subject' => event.payload[:subject],
@@ -34,8 +33,7 @@ module Rails
         end
 
         def deliver(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'mailer' => event.payload[:mailer],
             'message.id' => event.payload[:message_id],
             'message.subject' => event.payload[:subject],
@@ -51,8 +49,7 @@ module Rails
         end
 
         def process(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'mailer' => event.payload[:mailer],
             'action' => event.payload[:action],
             'args' => event.payload[:args]

--- a/lib/rails/instrumentation/subscribers/action_mailer_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_mailer_subscriber.rb
@@ -11,9 +11,14 @@ module Rails
         process
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActionMailer' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def receive(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'mailer' => event.payload[:mailer],
             'message.id' => event.payload[:message_id],
             'message.subject' => event.payload[:subject],
@@ -23,13 +28,14 @@ module Rails
             'message.cc' => event.payload[:cc],
             'message.date' => event.payload[:date],
             'message.body' => event.payload[:mail]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def deliver(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'mailer' => event.payload[:mailer],
             'message.id' => event.payload[:message_id],
             'message.subject' => event.payload[:subject],
@@ -39,17 +45,18 @@ module Rails
             'message.cc' => event.payload[:cc],
             'message.date' => event.payload[:date],
             'message.body' => event.payload[:mail]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def process(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'mailer' => event.payload[:mailer],
             'action' => event.payload[:action],
             'args' => event.payload[:args]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/action_view_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_view_subscriber.rb
@@ -17,8 +17,7 @@ module Rails
 
       class << self
         def render_template(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'template.identifier' => event.payload[:identifier],
             'template.layout' => event.payload[:layout]
           )
@@ -27,8 +26,7 @@ module Rails
         end
 
         def render_partial(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'partial.identifier' => event.payload[:identifier]
           )
 
@@ -36,8 +34,7 @@ module Rails
         end
 
         def render_collection(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'template.identifier' => event.payload[:identifier],
             'template.count' => event.payload[:count]
           )

--- a/lib/rails/instrumentation/subscribers/action_view_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/action_view_subscriber.rb
@@ -11,29 +11,36 @@ module Rails
         render_collection
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActionView' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def render_template(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'template.identifier' => event.payload[:identifier],
             'template.layout' => event.payload[:layout]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def render_partial(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'partial.identifier' => event.payload[:identifier]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def render_collection(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'template.identifier' => event.payload[:identifier],
             'template.count' => event.payload[:count]
-          }
+          )
           tags['template.cache_hits'] = event.payload[:cache_hits] if event.payload.key? :cache_hits
 
           Utils.trace_notification(event: event, tags: tags)

--- a/lib/rails/instrumentation/subscribers/active_job_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_job_subscriber.rb
@@ -12,39 +12,47 @@ module Rails
         perform
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActiveJob' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def enqueue_at(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def enqueue(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def perform_start(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def perform(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/active_job_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_job_subscriber.rb
@@ -18,8 +18,7 @@ module Rails
 
       class << self
         def enqueue_at(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
           )
@@ -28,8 +27,7 @@ module Rails
         end
 
         def enqueue(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
           )
@@ -38,8 +36,7 @@ module Rails
         end
 
         def perform_start(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
           )
@@ -48,8 +45,7 @@ module Rails
         end
 
         def perform(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'adapter' => event.payload[:adapter],
             'job' => event.payload[:job]
           )

--- a/lib/rails/instrumentation/subscribers/active_record_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_record_subscriber.rb
@@ -12,24 +12,30 @@ module Rails
         instantiation
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActiveRecord' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def sql(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'db.statement' => event.payload[:sql],
             'name' => event.payload[:name],
             'connection_id' => event.payload[:connection_id],
             'binds' => event.payload[:binds],
             'cached' => event.payload[:cached]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def instantiation(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'record.count' => event.payload[:record_count],
             'record.class' => event.payload[:class_name]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/active_record_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_record_subscriber.rb
@@ -18,8 +18,7 @@ module Rails
 
       class << self
         def sql(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'db.statement' => event.payload[:sql],
             'name' => event.payload[:name],
             'connection_id' => event.payload[:connection_id],
@@ -31,8 +30,7 @@ module Rails
         end
 
         def instantiation(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'record.count' => event.payload[:record_count],
             'record.class' => event.payload[:class_name]
           )

--- a/lib/rails/instrumentation/subscribers/active_storage_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_storage_subscriber.rb
@@ -15,69 +15,80 @@ module Rails
         service_url
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActiveStorage' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def service_upload(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'checksum' => event.payload[:checksum]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_streaming_download(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_download(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_delete(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_delete_prefixed(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key.prefix' => event.payload[:prefix],
             'service' => event.payload[:service]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_exist(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'exist' => event.payload[:exist]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def service_url(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'url' => event.payload[:url] # generated url, not accessed url
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/active_storage_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_storage_subscriber.rb
@@ -21,8 +21,7 @@ module Rails
 
       class << self
         def service_upload(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'checksum' => event.payload[:checksum]
@@ -32,8 +31,7 @@ module Rails
         end
 
         def service_streaming_download(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service]
           )
@@ -42,8 +40,7 @@ module Rails
         end
 
         def service_download(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service]
           )
@@ -52,8 +49,7 @@ module Rails
         end
 
         def service_delete(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service]
           )
@@ -62,8 +58,7 @@ module Rails
         end
 
         def service_delete_prefixed(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key.prefix' => event.payload[:prefix],
             'service' => event.payload[:service]
           )
@@ -72,8 +67,7 @@ module Rails
         end
 
         def service_exist(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'exist' => event.payload[:exist]
@@ -83,8 +77,7 @@ module Rails
         end
 
         def service_url(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'service' => event.payload[:service],
             'url' => event.payload[:url] # generated url, not accessed url

--- a/lib/rails/instrumentation/subscribers/active_support_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_support_subscriber.rb
@@ -14,53 +14,63 @@ module Rails
         cache_exist?
       ].freeze
 
+      # rubocop:disable Style/MutableConstant
+      BASE_TAGS = { 'component' => 'ActiveSupport' }
+      # rubocop:enable Style/MutableConstant.
+
       class << self
         def cache_read(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key],
             'hit' => event.payload[:hit],
             'super_operation' => event.payload[:super_operation]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def cache_generate(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def cache_fetch_hit(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def cache_write(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def cache_delete(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end
 
         def cache_exist?(event)
-          tags = {
+          tags = Utils.merged_tags(
+            BASE_TAGS,
             'key' => event.payload[:key]
-          }
+          )
 
           Utils.trace_notification(event: event, tags: tags)
         end

--- a/lib/rails/instrumentation/subscribers/active_support_subscriber.rb
+++ b/lib/rails/instrumentation/subscribers/active_support_subscriber.rb
@@ -20,8 +20,7 @@ module Rails
 
       class << self
         def cache_read(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key],
             'hit' => event.payload[:hit],
             'super_operation' => event.payload[:super_operation]
@@ -31,8 +30,7 @@ module Rails
         end
 
         def cache_generate(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key]
           )
 
@@ -40,8 +38,7 @@ module Rails
         end
 
         def cache_fetch_hit(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key]
           )
 
@@ -49,8 +46,7 @@ module Rails
         end
 
         def cache_write(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key]
           )
 
@@ -58,8 +54,7 @@ module Rails
         end
 
         def cache_delete(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key]
           )
 
@@ -67,8 +62,7 @@ module Rails
         end
 
         def cache_exist?(event)
-          tags = Utils.merged_tags(
-            BASE_TAGS,
+          tags = span_tags(
             'key' => event.payload[:key]
           )
 

--- a/lib/rails/instrumentation/utils.rb
+++ b/lib/rails/instrumentation/utils.rb
@@ -41,12 +41,6 @@ module Rails
           span.log_kv(key: 'message', value: payload[:exception].last)
           span.log_kv(key: 'error.object', value: payload[:exception_object])
         end
-
-        # takes a base_tags hash whose clone will be merged with provided
-        # additional tags.  All provided tag hashes will not be modified
-        def merged_tags(base_tags, tags)
-          base_tags.clone.merge(tags)
-        end
       end
     end
   end

--- a/lib/rails/instrumentation/utils.rb
+++ b/lib/rails/instrumentation/utils.rb
@@ -18,7 +18,7 @@ module Rails
         # takes and event and some set of tags from a handler, and creates a
         # span with the event's name and the start and finish times.
         def trace_notification(event:, tags: [])
-          tags = tags.merge(::Rails::Instrumentation::TAGS)
+          tags = ::Rails::Instrumentation::TAGS.clone.merge(tags)
 
           span = ::Rails::Instrumentation.tracer.start_span(event.name,
                                                             tags: tags,
@@ -40,6 +40,12 @@ module Rails
           span.log_kv(key: 'error.kind', value: payload[:exception].first)
           span.log_kv(key: 'message', value: payload[:exception].last)
           span.log_kv(key: 'error.object', value: payload[:exception_object])
+        end
+
+        # takes a base_tags hash whose clone will be merged with provided
+        # additional tags.  All provided tag hashes will not be modified
+        def merged_tags(base_tags, tags)
+          base_tags.clone.merge(tags)
         end
       end
     end


### PR DESCRIPTION
These changes add applicable `component` tags to all instrumentations and `span.kind` for the initial Action Controller method.  Also shifts to the more intuitive `class.method` operation name.