### PR TITLE
Adds hook to add custom subscribers

### DIFF
--- a/lib/rails/instrumentation.rb
+++ b/lib/rails/instrumentation.rb
@@ -23,10 +23,14 @@ module Rails
     }.freeze
 
     def self.instrument(tracer: OpenTracing.global_tracer,
-                        exclude_events: [])
+                        exclude_events: [],
+                        custom_subscribers: nil)
       @tracer = tracer
 
       add_subscribers(exclude_events: exclude_events)
+
+      custom_subscribers&.call(exclude_events: exclude_events)
+
       Patch.patch_process_action
     end
 


### PR DESCRIPTION
Hello,

I've just starting to use `ruby-rails-instrumentation` and one of the features I was missing is to add my own subscribers. In this PR I'm introducing a hook so I can add my own subscribers to the tracer. What do you think? Or have I missed some existing feature that allows me to do this already?

Usage:
```
  Rails::Instrumentation.instrument(
    tracer: tracer,
    custom_subscribers: ->(exclude_events) do
      Instrumentation::GraphqlSubscriber.subscribe(exclude_events: exclude_events)
    end
  )
```
If you think this is merge worthy, please let me know so I can add some specs.

Thanks,

Willian

